### PR TITLE
Fix for usage with the Addon MobileFrames

### DIFF
--- a/postal.lua
+++ b/postal.lua
@@ -98,8 +98,8 @@ end
 function ADDON_LOADED()
 	if arg1 ~= 'postal' then return end
 
-	UIPanelWindows.MailFrame.pushable = 1
-	UIPanelWindows.FriendsFrame.pushable = 2
+	MailFrame.pushable = 1
+	FriendsFrame.pushable = 2
 
 	Inbox_Load()
 	SendMail_Load()


### PR DESCRIPTION
The addon MobileFrames changes the parent. So you get a LUA error at those lines. After this change, it works with and without MobileFrames.
MobileFrames: https://drive.google.com/file/d/0BxUEpLqG5Y0Edm5HbFNWdjFtbWM/view