### PR TITLE
Allows for multiple mail CoD

### DIFF
--- a/Mail.lua
+++ b/Mail.lua
@@ -671,10 +671,10 @@ function SendMail_Send()
 
 	local amount = SendMail_state.money
 	if amount > 0 then
-		SendMail_state.money = 0
 		if SendMail_state.cod then
 			SetSendMailCOD(amount)
 		else
+			SendMail_state.money = 0
 			SetSendMailMoney(amount)
 		end
 	end


### PR DESCRIPTION
I was quite annoyed that I could not send multiple items with the same CoD amount attached. So I took a look at the code and found a super simple fix for that.

By only resetting the gold on a gold transfer and not on a CoD the if statement stays true for all mails sent, allowing for more CoD mails to be sent.